### PR TITLE
Add support to use rust as script in rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["scripting_api", "script_manager"]
+members = ["scripting_api", "rust_scripts", "script_manager"]

--- a/rust_scripts/Cargo.toml
+++ b/rust_scripts/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust_scripts"
+version = "0.1.0"
+authors = ["Pablo Diego <pablodiegoss@hotmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+scripting_api = {path = "../scripting_api"}
+
+[lib]
+crate-type = ["cdylib"]

--- a/rust_scripts/src/lib.rs
+++ b/rust_scripts/src/lib.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_int;
 
 #[no_mangle]
-fn multii(numero:c_int) -> c_int{
-    println!("Rust: Calculando {} ao cubo.\n", numero);
-    return numero.pow(2);
+fn sum_three(number:c_int) -> c_int{
+    println!("Rust: calculating {} + 3.\n", number);
+    return number + 3;
 }

--- a/rust_scripts/src/lib.rs
+++ b/rust_scripts/src/lib.rs
@@ -1,0 +1,7 @@
+use std::os::raw::c_int;
+
+#[no_mangle]
+fn multii(numero:c_int) -> c_int{
+    println!("Rust: Calculando {} ao cubo.\n", numero);
+    return numero.pow(2);
+}

--- a/script_manager/.cargo/config
+++ b/script_manager/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "link-args=-lscripting_api -L../target/debug"]

--- a/script_manager/Cargo.toml
+++ b/script_manager/Cargo.toml
@@ -10,6 +10,7 @@ links = "lua"
 [dependencies]
 libc = "0.2.0"
 scripting_api = {path = "../scripting_api"}
+rust_scripts = {path = "../rust_scripts"}
 
 [build-dependencies]
 cc = "1.0"

--- a/script_manager/build.rs
+++ b/script_manager/build.rs
@@ -1,67 +1,38 @@
 
 extern crate cc;
 use std::env;
+use std::process::Command;
+use std::io::{self, Write};
 
 fn main() {
-    match pkg_config::find_library("lua5.3") {
-        Ok(_) => return,
-        Err(..) => {}
-    };
-
-    let mut build = cc::Build::new();
-
-    if env::var("CARGO_CFG_TARGET_OS") == Ok("linux".to_string()) {
-        // Enable `io.popen` support
-        build.define("LUA_USE_LINUX", None);
-    }
-
-    build
-        .file("lua/src/lapi.c")
-        .file("lua/src/lcode.c")
-        .file("lua/src/lctype.c")
-        .file("lua/src/ldebug.c")
-        .file("lua/src/ldo.c")
-        .file("lua/src/ldump.c")
-        .file("lua/src/lfunc.c")
-        .file("lua/src/lgc.c")
-        .file("lua/src/llex.c")
-        .file("lua/src/lmem.c")
-        .file("lua/src/lobject.c")
-        .file("lua/src/lopcodes.c")
-        .file("lua/src/lparser.c")
-        .file("lua/src/lstate.c")
-        .file("lua/src/lstring.c")
-        .file("lua/src/ltable.c")
-        .file("lua/src/ltm.c")
-        .file("lua/src/lundump.c")
-        .file("lua/src/lvm.c")
-        .file("lua/src/lzio.c")
-        .file("lua/src/lauxlib.c")
-        .file("lua/src/lbaselib.c")
-        .file("lua/src/lbitlib.c")
-        .file("lua/src/lcorolib.c")
-        .file("lua/src/ldblib.c")
-        .file("lua/src/liolib.c")
-        .file("lua/src/lmathlib.c")
-        .file("lua/src/loslib.c")
-        .file("lua/src/lstrlib.c")
-        .file("lua/src/ltablib.c")
-        .file("lua/src/loadlib.c")
-        .file("lua/src/lutf8lib.c")
-        .file("lua/src/linit.c")
-        .define("LUA_COMPAT_ALL", None)
-        .include("lua/src")
-        .compile("liblua.a");
-    
-    cc::Build::new()
+    if cfg!(target_os = "linux") {
+        Command::new("make")
+        .current_dir("lua/src")
+        .status()
+        .expect("failed to execute process");
+        
+        let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        cc::Build::new()
         .flag("-I")
         .flag("lua/src/")
-        .flag("-llua")
-        .object("../target/debug/libscripting_api.so")
-        //.flag("-lscripting_api")
-        //.flag("-L~/Documents/repos/stainless-experiments/mock/target/debug/")
+        .flag("-llua53")
+        .flag("-lscripting_api")
+        .flag("-L/home/pablo/repositorioGit/stainless-experiments/target/debug")
         .file("drivers/lua_vm.c")
         .compile("lua_vm");
+        
+        cc::Build::new()
+        // .flag(format!("-L/home/pablo/repositorioGit/stainless-experiments/script_manager")
+        .flag(format!("-L{}/scripts",crate_dir).as_str())
+        .flag(format!("-L{}../target/debug",crate_dir).as_str())
+        .flag("-lrust_scripts")
+        .flag("-lscripting_api")
+        .file("drivers/rust_vm.c")
+        .compile("rust_vm");
+        
+        // println!("cargo:rustc-flags=-L lua/src -l lua53");
         println!("cargo:rustc-flags=-L {}/target/debug -l scripting_api", crate_dir);
         println!("cargo:rustc-flags= -l rust_scripts");
+        // println!("cargo:rustc-flags=-l python3.9 -L python/src/cpython");
+    }
 }

--- a/script_manager/build.rs
+++ b/script_manager/build.rs
@@ -15,14 +15,13 @@ fn main() {
         cc::Build::new()
         .flag("-I")
         .flag("lua/src/")
-        .flag("-llua53")
+        .flag("-llua")
         .flag("-lscripting_api")
         .flag("-L/home/pablo/repositorioGit/stainless-experiments/target/debug")
         .file("drivers/lua_vm.c")
         .compile("lua_vm");
         
         cc::Build::new()
-        // .flag(format!("-L/home/pablo/repositorioGit/stainless-experiments/script_manager")
         .flag(format!("-L{}/scripts",crate_dir).as_str())
         .flag(format!("-L{}../target/debug",crate_dir).as_str())
         .flag("-lrust_scripts")
@@ -30,9 +29,8 @@ fn main() {
         .file("drivers/rust_vm.c")
         .compile("rust_vm");
         
-        // println!("cargo:rustc-flags=-L lua/src -l lua53");
+        println!("cargo:rustc-flags=-L {}/script_manager/lua/src -l lua", crate_dir);
         println!("cargo:rustc-flags=-L {}/target/debug -l scripting_api", crate_dir);
         println!("cargo:rustc-flags= -l rust_scripts");
-        // println!("cargo:rustc-flags=-l python3.9 -L python/src/cpython");
     }
 }

--- a/script_manager/build.rs
+++ b/script_manager/build.rs
@@ -62,4 +62,6 @@ fn main() {
         //.flag("-L~/Documents/repos/stainless-experiments/mock/target/debug/")
         .file("drivers/lua_vm.c")
         .compile("lua_vm");
+        println!("cargo:rustc-flags=-L {}/target/debug -l scripting_api", crate_dir);
+        println!("cargo:rustc-flags= -l rust_scripts");
 }

--- a/script_manager/build.rs
+++ b/script_manager/build.rs
@@ -17,7 +17,8 @@ fn main() {
         .flag("lua/src/")
         .flag("-llua")
         .flag("-lscripting_api")
-        .flag("-L/home/pablo/repositorioGit/stainless-experiments/target/debug")
+        .flag(format!("-Wl, -rpath={}/lua/src", crate_dir).as_str())
+        .flag(format!("-L{}/../target/debug",crate_dir).as_str())
         .file("drivers/lua_vm.c")
         .compile("lua_vm");
         

--- a/script_manager/drivers/lua_vm.c
+++ b/script_manager/drivers/lua_vm.c
@@ -18,8 +18,6 @@ static int wrapper_log(lua_State *L) {
 }
 
 void call_lua(int* state, const char* script) {
-  //  pwd();
-    //rust_log("DEU BOM PORRA");
     lua_State *L;
     L = luaL_newstate();
     printf("C: loading lua script %s\n", script);

--- a/script_manager/drivers/lua_vm.c
+++ b/script_manager/drivers/lua_vm.c
@@ -1,9 +1,7 @@
-#include <lua.h>
-#include <lauxlib.h>
-#include <lualib.h> 
-
-
 #include <stdio.h>
+#include <lualib.h>
+#include <lauxlib.h>
+#include <lua.h>
 
 extern void rust_log(char *s);
 

--- a/script_manager/drivers/rust_vm.c
+++ b/script_manager/drivers/rust_vm.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+// Function declared in rust, received as -lscripting_api during cc::build of rust_vm.c
+extern void rust_log(char *s);
+
+// Function declared in rust_scritps, received as -lrust_scripts during cc::build of rust_vm.c
+extern int multii(int);
+
+static int wrapper_log(char* msg) {
+   rust_log(msg);
+   return 1;
+}
+
+void call_rust(int* state,const char* script) {
+    rust_log("C: DEU BOM PORRA");
+   
+    printf("C: state is %d\n", (int) *state);
+    *state = multii(*state);
+    printf("C: new state is %d\n", (int) *state);
+}

--- a/script_manager/drivers/rust_vm.c
+++ b/script_manager/drivers/rust_vm.c
@@ -4,7 +4,7 @@
 extern void rust_log(char *s);
 
 // Function declared in rust_scritps, received as -lrust_scripts during cc::build of rust_vm.c
-extern int multii(int);
+extern int sum_three(int);
 
 static int wrapper_log(char* msg) {
    rust_log(msg);
@@ -12,9 +12,9 @@ static int wrapper_log(char* msg) {
 }
 
 void call_rust(int* state,const char* script) {
-    rust_log("C: DEU BOM PORRA");
+    rust_log("C: Running rust_vm.c");
    
     printf("C: state is %d\n", (int) *state);
-    *state = multii(*state);
+    *state = sum_three(*state);
     printf("C: new state is %d\n", (int) *state);
 }

--- a/script_manager/src/main.rs
+++ b/script_manager/src/main.rs
@@ -9,7 +9,10 @@ extern{
 
 fn exec_script(state: *mut i32, script_path: &str) {
     println!("RUST: loading {} script", script_path);
-    let extension = script_path.split(".").next().unwrap();
+    let mut iter = script_path.split(".");
+    iter.next();
+    let extension = iter.next().unwrap();
+    println!("RUST:extension : {}", extension);
     unsafe {
         if extension == String::from("rs"){
             call_rust(state, CString::new(script_path).expect("CString::new failed").as_ptr());

--- a/script_manager/src/main.rs
+++ b/script_manager/src/main.rs
@@ -4,13 +4,18 @@ use std::os::raw::{c_char, c_int};
 
 extern{
     fn call_lua(state: *mut c_int, script: *const c_char);
+    fn call_rust(state: *mut c_int, script: *const c_char);
 }
 
 fn exec_script(state: *mut i32, script_path: &str) {
     println!("RUST: loading {} script", script_path);
+    let extension = script_path.split(".").next().unwrap();
     unsafe {
-        //let raw_ptr = &mut state as *mut i32;
-        call_lua(state, CString::new(script_path).expect("CString::new failed").as_ptr());
+        if extension == String::from("rs"){
+            call_rust(state, CString::new(script_path).expect("CString::new failed").as_ptr());
+        }else if extension == String::from("lua"){
+            call_lua(state, CString::new(script_path).expect("CString::new failed").as_ptr());
+        }
         println!("RUST: new_ptr value {}", *state);
     }
 }
@@ -27,7 +32,8 @@ fn main() {
     loop {
         print!("\n");
         exec_script(&mut state, "script_manager/scripts/calc.lua");
+        exec_script(&mut state, "rust_scripts/src/lib.rs");
         output(state);
-        thread::sleep(time::Duration::from_millis(1000)); 
+        thread::sleep(time::Duration::from_millis(1000));
     }
 }


### PR DESCRIPTION
Using rust on the scripting system will allow us to measure the performance impact of running code in the scripting system. 
The RFC defined that "running rust as a script should run as fast as native rust". 